### PR TITLE
"add save files" and "add ps2exe-script update" implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ As you may have noticed, the project has not been updated for a while. I will ge
 | add about page                   | ✅ | ✅ |
 | mark required ps2exe fields      | ✅ | ✅ |
 | get ps2exe call done             | ✅ | ✅ |
-| add ps2exe-script update         | ⏳ | *not specified* |
+| add ps2exe-script update         | ✅ | ✅ |
 | release first build              | ⏳ | *not specified* |
-| add save files                   | ⏳ | *not specified* |
+| add save files                   | ✅ | ✅ |
 | release second build             | ⏳ | *not specified* |
 | integrate [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) | 🔜 | *not specified* |
 | release third build              | 🔜 | *not specified* |

--- a/README.md
+++ b/README.md
@@ -11,21 +11,42 @@ This project provides a advanced graphical user interface for [PS2EXE](https://g
 
 PS2EXE-GUI is still in development but is usable.
 
-As you may have noticed, the project has not been updated for a while. I will get back to it as soon as possible. I'm sorry for the inconvenience.
-
 | Feature                          | Status | ETA |
 |----------------------------------|--------|-----|
-| add all p2exe fields             | ✅ | ✅ |
+| add all ps2exe fields            | ✅ | ✅ |
 | add tooltip to all ps2exe fields | ✅ | ✅ |
 | add about page                   | ✅ | ✅ |
 | mark required ps2exe fields      | ✅ | ✅ |
 | get ps2exe call done             | ✅ | ✅ |
 | add ps2exe-script update         | ✅ | ✅ |
-| release first build              | ⏳ | *not specified* |
 | add save files                   | ✅ | ✅ |
+| release first build              | ⏳ | *not specified* |
 | release second build             | ⏳ | *not specified* |
 | integrate [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) | 🔜 | *not specified* |
 | release third build              | 🔜 | *not specified* |
+
+### Recently completed
+
+- [x] Fix initial `TabIndex` (2 → 0) so the app opens on the Main page instead of the Console page
+- [x] Enable File menu items (New, Open, Save, Save As) in XAML
+- [x] Implement `Invoke-PS2EXEGUI_NewConfig` — resets all 28 fields to canonical defaults via `$global:PS2EXE_GUI_DEFAULTS`
+- [x] Implement `Invoke-PS2EXEGUI_SaveConfig` — serialises current `$State` to a `.json` file
+- [x] Implement `Invoke-PS2EXEGUI_OpenConfig` — type-safe deserialisation (`bool` via `[System.Convert]::ToBoolean` with default fallback, explicit string casts)
+- [x] Implement UI helpers `Invoke-UI_SaveConfig`, `Invoke-UI_SaveAsConfig`, `Invoke-UI_OpenConfig`
+- [x] Implement `Install-PS2EXEUpdate` helper — copies temp → dest, verifies write, shows result (no duplication)
+- [x] Implement `Invoke-PS2EXEGUI_CheckPS2EXEUpdate` — `New-TemporaryFile`, SHA-256 hash comparison, calls `Install-PS2EXEUpdate`, cleans up in `finally`
+- [x] Wire all new handlers into `Invoke-WindowLoaded`
+- [x] Add shared constants: `$global:PS2EXE_GUI_DEFAULTS`, `$global:PS2EXE_GUI_CONFIG_FILTER`, `$global:PS2EXE_PS1_RAW_URL`
+- [x] Resolve `ps2exe.ps1` path via `$PSScriptRoot` instead of `Get-Location`
+- [x] Fix menu typo: `_About P2EXE-GUI` → `_About PS2EXE-GUI`
+
+### Still to do
+
+- [ ] Release first build
+- [ ] Release second build
+- [ ] Integrate [PSScriptAnalyzer](https://github.com/PowerShell/PSScriptAnalyzer) for script linting
+- [ ] Release third build
+- [ ] BONUS: implement `extractable` option (allow users to choose whether the `.ps1` can be extracted from the compiled `.exe`)
 
 ## Parameter Support Comparison
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PS2EXE-GUI is still in development but is usable.
 
 - [x] Fix initial `TabIndex` (2 → 0) so the app opens on the Main page instead of the Console page
 - [x] Enable File menu items (New, Open, Save, Save As) in XAML
-- [x] Implement `Invoke-PS2EXEGUI_NewConfig` — resets all 28 fields to canonical defaults via `$global:PS2EXE_GUI_DEFAULTS`
+- [x] Implement `Invoke-PS2EXEGUI_NewConfig` — resets all 28 fields to canonical defaults via `$script:PS2EXE_GUI_DEFAULTS`
 - [x] Implement `Invoke-PS2EXEGUI_SaveConfig` — serialises current `$State` to a `.json` file
 - [x] Implement `Invoke-PS2EXEGUI_OpenConfig` — type-safe deserialisation (`bool` via `[System.Convert]::ToBoolean` with default fallback, explicit string casts)
 - [x] Implement UI helpers `Invoke-UI_SaveConfig`, `Invoke-UI_SaveAsConfig`, `Invoke-UI_OpenConfig`

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ PS2EXE-GUI is still in development but is usable.
 - [x] Implement `Install-PS2EXEUpdate` helper — copies temp → dest, verifies write, shows result (no duplication)
 - [x] Implement `Invoke-PS2EXEGUI_CheckPS2EXEUpdate` — `New-TemporaryFile`, SHA-256 hash comparison, calls `Install-PS2EXEUpdate`, cleans up in `finally`
 - [x] Wire all new handlers into `Invoke-WindowLoaded`
-- [x] Add shared constants: `$global:PS2EXE_GUI_DEFAULTS`, `$global:PS2EXE_GUI_CONFIG_FILTER`, `$global:PS2EXE_PS1_RAW_URL`
+- [x] Add shared ($Script:) constants: `$script:PS2EXE_GUI_DEFAULTS`, `$script:PS2EXE_GUI_CONFIG_FILTER`, `$script:PS2EXE_PS1_RAW_URL`
 - [x] Resolve `ps2exe.ps1` path via `$PSScriptRoot` instead of `Get-Location`
 - [x] Fix menu typo: `_About P2EXE-GUI` → `_About PS2EXE-GUI`
 

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -145,10 +145,10 @@ $Xaml = @"
 
 #region pre_code
 $PS2EXE_GUI_Verbose = $true
-$global:PS2EXE_GUI_ConfigPath = $null
-$global:PS2EXE_GUI_CONFIG_FILTER = "PS2EXE-GUI Config (*.json)|*.json"
-$global:PS2EXE_PS1_RAW_URL = "https://raw.githubusercontent.com/MScholtes/Win-PS2EXE/master/ps2exe.ps1"
-$global:PS2EXE_GUI_CONFIG_KEYS = @(
+$script:PS2EXE_GUI_ConfigPath = $null
+$script:PS2EXE_GUI_CONFIG_FILTER = "PS2EXE-GUI Config (*.json)|*.json"
+$script:PS2EXE_PS1_RAW_URL = "https://raw.githubusercontent.com/MScholtes/Win-PS2EXE/master/ps2exe.ps1"
+$script:PS2EXE_GUI_CONFIG_KEYS = @(
     'ui_inputFile','ui_outputFile','ui_iconFile',
     'ui_title','ui_description','ui_company','ui_product','ui_copyright','ui_trademark','ui_version',
     'value_runtime','value_instructionSet','value_threadApartment',
@@ -156,7 +156,7 @@ $global:PS2EXE_GUI_CONFIG_KEYS = @(
     'ui_noOutput','ui_noError','ui_noVisualStyles','ui_exitOnCancel',
     'ui_DPIAware','ui_winFormsDPIAware','ui_requireAdmin','ui_supportOS','ui_virtualize','ui_longPaths'
 )
-$global:PS2EXE_GUI_DEFAULTS = [ordered]@{
+$script:PS2EXE_GUI_DEFAULTS = [ordered]@{
     'ui_inputFile'         = ''
     'ui_outputFile'        = ''
     'ui_iconFile'          = ''
@@ -463,25 +463,25 @@ function Invoke-PS2EXE {
 
 function Invoke-PS2EXEGUI_NewConfig {
     if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_NewConfig]" }
-    $global:PS2EXE_GUI_DEFAULTS.GetEnumerator() | ForEach-Object { $State.($_.Key) = $_.Value }
-    $global:PS2EXE_GUI_ConfigPath = $null
+    $script:PS2EXE_GUI_DEFAULTS.GetEnumerator() | ForEach-Object { $State.($_.Key) = $_.Value }
+    $script:PS2EXE_GUI_ConfigPath = $null
 }
 
 function Invoke-PS2EXEGUI_SaveConfig ($FilePath) {
     if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_SaveConfig] FilePath: "+$FilePath) }
     $Config = [ordered]@{}
-    $global:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object { $Config[$_] = $State.$_ }
+    $script:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object { $Config[$_] = $State.$_ }
     $Config | ConvertTo-Json | Set-Content -Path $FilePath -Encoding UTF8
-    $global:PS2EXE_GUI_ConfigPath = $FilePath
+    $script:PS2EXE_GUI_ConfigPath = $FilePath
 }
 
 function Invoke-PS2EXEGUI_OpenConfig ($FilePath) {
     if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_OpenConfig] FilePath: "+$FilePath) }
     $Config = Get-Content -Path $FilePath -Raw -Encoding UTF8 | ConvertFrom-Json
-    $global:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object {
+    $script:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object {
         $key = $_
         if($null -ne $Config.$key){
-            $defaultVal = $global:PS2EXE_GUI_DEFAULTS[$key]
+            $defaultVal = $script:PS2EXE_GUI_DEFAULTS[$key]
             if($defaultVal -is [bool]){
                 try { $State.$key = [System.Convert]::ToBoolean($Config.$key) }
                 catch { $State.$key = $defaultVal }
@@ -490,24 +490,24 @@ function Invoke-PS2EXEGUI_OpenConfig ($FilePath) {
             }
         }
     }
-    $global:PS2EXE_GUI_ConfigPath = $FilePath
+    $script:PS2EXE_GUI_ConfigPath = $FilePath
 }
 
 function Invoke-UI_SaveConfig {
-    if($null -ne $global:PS2EXE_GUI_ConfigPath){
-        Invoke-PS2EXEGUI_SaveConfig -FilePath $global:PS2EXE_GUI_ConfigPath
+    if($null -ne $script:PS2EXE_GUI_ConfigPath){
+        Invoke-PS2EXEGUI_SaveConfig -FilePath $script:PS2EXE_GUI_ConfigPath
     } else {
         Invoke-UI_SaveAsConfig
     }
 }
 
 function Invoke-UI_SaveAsConfig {
-    $FilePath = Invoke-PS2EXEGUI_SaveFileDialog -Filter $global:PS2EXE_GUI_CONFIG_FILTER
+    $FilePath = Invoke-PS2EXEGUI_SaveFileDialog -Filter $script:PS2EXE_GUI_CONFIG_FILTER
     if($FilePath -ne ""){ Invoke-PS2EXEGUI_SaveConfig -FilePath $FilePath }
 }
 
 function Invoke-UI_OpenConfig {
-    $FilePath = Invoke-PS2EXEGUI_OpenFileDialog -Filter $global:PS2EXE_GUI_CONFIG_FILTER
+    $FilePath = Invoke-PS2EXEGUI_OpenFileDialog -Filter $script:PS2EXE_GUI_CONFIG_FILTER
     if($FilePath -ne ""){ Invoke-PS2EXEGUI_OpenConfig -FilePath $FilePath }
 }
 
@@ -524,7 +524,7 @@ function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
     if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_CheckPS2EXEUpdate]" }
     $TempFile = (New-TemporaryFile).FullName
     try {
-        Invoke-WebRequest -Uri $global:PS2EXE_PS1_RAW_URL -OutFile $TempFile -UseBasicParsing
+        Invoke-WebRequest -Uri $script:PS2EXE_PS1_RAW_URL -OutFile $TempFile -UseBasicParsing
         $LocalPS2EXE = Join-Path $PSScriptRoot "ps2exe.ps1"
         if(Test-Path -Path $LocalPS2EXE){
             $LocalHash  = (Get-FileHash -Path $LocalPS2EXE -Algorithm SHA256).Hash

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -765,7 +765,7 @@ Set-Binding -Target $dom_checkbox_extractable -Property $([System.Windows.Contro
 Set-Binding -Target $dom_button_compile -Property $([System.Windows.Controls.Button]::IsEnabledProperty) -Index 59 -Name "state_compile"  
 Set-Binding -Target $PS2EXE_Console -Property $([System.Windows.Controls.TextBox]::TextProperty) -Index 65 -Name "value_console"  
 Set-Binding -Target $ui_dockpanel19 -Property $([System.Windows.Controls.Button]::IsEnabledProperty) -Index 60 -Name "state_compiled"  
-$Global:SyncHash = [HashTable]::Synchronized(@{})
+$script:SyncHash = [HashTable]::Synchronized(@{})
 $SyncHash.Window = $Window
 $Jobs = [System.Collections.ArrayList]::Synchronized([System.Collections.ArrayList]::new())
 $initialSessionState = [initialsessionstate]::CreateDefault()

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -512,11 +512,17 @@ function Invoke-UI_OpenConfig {
 }
 
 function Install-PS2EXEUpdate ($TempFile, $Destination, $SuccessMessage) {
-    Copy-Item -Path $TempFile -Destination $Destination -Force
-    if(Test-Path -Path $Destination){
-        [System.Windows.MessageBox]::Show($SuccessMessage, "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
-    } else {
-        [System.Windows.MessageBox]::Show("The file could not be saved. Please check write permissions.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
+    try {
+        Copy-Item -Path $TempFile -Destination $Destination -Force -ErrorAction Stop
+        $destHash = (Get-FileHash -Path $Destination -Algorithm SHA256).Hash
+        $tempHash = (Get-FileHash -Path $TempFile -Algorithm SHA256).Hash
+        if($destHash -eq $tempHash){
+            [System.Windows.MessageBox]::Show($SuccessMessage, "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+        } else {
+            [System.Windows.MessageBox]::Show("The file was written but does not match the downloaded content. Please try again.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
+        }
+    } catch {
+        [System.Windows.MessageBox]::Show("The file could not be saved:`n"+$_.Exception.Message, "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
     }
 }
 

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -318,14 +318,14 @@ function Invoke-UI_iconFile {
 
 function Add-PS2EXE_Argument ($Key,$Value) {
     if($null -eq $Value){
-        $global:PS2EXE_Arguments.Add("-"+$Key)
+        $script:PS2EXE_Arguments.Add("-"+$Key)
     } else {
-        $global:PS2EXE_Arguments.Add("-"+$Key+' "'+$Value+'"')
+        $script:PS2EXE_Arguments.Add("-"+$Key+' "'+$Value+'"')
     }
 }
 
 function Invoke-PS2EXE {
-    $global:PS2EXE_Arguments = New-Object -TypeName System.Collections.ArrayList
+    $script:PS2EXE_Arguments = New-Object -TypeName System.Collections.ArrayList
 
     <#
         KEY/VALUE-PARAMETERS
@@ -396,7 +396,7 @@ function Invoke-PS2EXE {
         $PS2EXE_SOURCE = $PS2EXE_SOURCE -replace 's.StartsWith("-extdummt".Replace("dumm", "rac"), StringComparison.InvariantCultureIgnoreCase)','false'
     #>
     Switch-Page -Page 2
-    $PS2EXE_CMD = '".\ps2exe.ps1" '+$global:PS2EXE_Arguments
+    $PS2EXE_CMD = '".\ps2exe.ps1" '+$script:PS2EXE_Arguments
     $State.value_console_command = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes([string]$PS2EXE_CMD))
     $State.value_console_root = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes((Get-Location).Path))
     Async {

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -146,6 +146,7 @@ $Xaml = @"
 #region pre_code
 $PS2EXE_GUI_Verbose = $true
 $global:PS2EXE_GUI_ConfigPath = $null
+$global:PS2EXE_GUI_CONFIG_FILTER = "PS2EXE-GUI Config (*.json)|*.json"
 $global:PS2EXE_GUI_CONFIG_KEYS = @(
     'ui_inputFile','ui_outputFile','ui_iconFile',
     'ui_title','ui_description','ui_company','ui_product','ui_copyright','ui_trademark','ui_version',
@@ -154,6 +155,36 @@ $global:PS2EXE_GUI_CONFIG_KEYS = @(
     'ui_noOutput','ui_noError','ui_noVisualStyles','ui_exitOnCancel',
     'ui_DPIAware','ui_winFormsDPIAware','ui_requireAdmin','ui_supportOS','ui_virtualize','ui_longPaths'
 )
+$global:PS2EXE_GUI_DEFAULTS = [ordered]@{
+    'ui_inputFile'         = ''
+    'ui_outputFile'        = ''
+    'ui_iconFile'          = ''
+    'ui_title'             = ''
+    'ui_description'       = ''
+    'ui_company'           = ''
+    'ui_product'           = ''
+    'ui_copyright'         = ''
+    'ui_trademark'         = ''
+    'ui_version'           = ''
+    'value_runtime'        = '[runtime40] .NET Framework 4.x for PowerShell 3.0'
+    'value_instructionSet' = 'x86 - 32-Bit Application'
+    'value_threadApartment'= 'STA - Single Thread Apartment'
+    'ui_prepareDebug'      = $false
+    'ui_noConsole'         = $false
+    'ui_UNICODEEncoding'   = $true
+    'ui_credentialGUI'     = $false
+    'ui_configFile'        = $false
+    'ui_noOutput'          = $false
+    'ui_noError'           = $false
+    'ui_noVisualStyles'    = $false
+    'ui_exitOnCancel'      = $false
+    'ui_DPIAware'          = $false
+    'ui_winFormsDPIAware'  = $false
+    'ui_requireAdmin'      = $false
+    'ui_supportOS'         = $true
+    'ui_virtualize'        = $false
+    'ui_longPaths'         = $false
+}
 
 Add-Type -AssemblyName System.Windows.Forms
 
@@ -212,7 +243,7 @@ $Xaml = $Xaml.Replace('<!--d9102811-1fab-4eca-a3f6-f5b6db64722b-->',@'
             <MenuItem Header="_Check for PS2EXE-GUI Update" Name="ui_dockpanel08"/>
             <MenuItem Header="_Check for ps2exe.ps1 Update" Name="ui_dockpanel09"/>
             <Separator />
-            <MenuItem Header="_About P2EXE-GUI" Name="ui_dockpanel10"/>
+            <MenuItem Header="_About PS2EXE-GUI" Name="ui_dockpanel10"/>
         </MenuItem>
     </Menu>
 '@)
@@ -431,17 +462,7 @@ function Invoke-PS2EXE {
 
 function Invoke-PS2EXEGUI_NewConfig {
     if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_NewConfig]" }
-    @('ui_inputFile','ui_outputFile','ui_iconFile','ui_title','ui_description','ui_company','ui_product','ui_copyright','ui_trademark','ui_version') | ForEach-Object {
-        $State.$_ = ""
-    }
-    $State.value_runtime = "[runtime40] .NET Framework 4.x for PowerShell 3.0"
-    $State.value_instructionSet = "x86 - 32-Bit Application"
-    $State.value_threadApartment = "STA - Single Thread Apartment"
-    @('ui_prepareDebug','ui_noConsole','ui_credentialGUI','ui_configFile','ui_noOutput','ui_noError','ui_noVisualStyles','ui_exitOnCancel','ui_DPIAware','ui_winFormsDPIAware','ui_requireAdmin','ui_virtualize','ui_longPaths') | ForEach-Object {
-        $State.$_ = $false
-    }
-    $State.ui_UNICODEEncoding = $true
-    $State.ui_supportOS = $true
+    $global:PS2EXE_GUI_DEFAULTS.GetEnumerator() | ForEach-Object { $State.($_.Key) = $_.Value }
     $global:PS2EXE_GUI_ConfigPath = $null
 }
 
@@ -471,12 +492,12 @@ function Invoke-UI_SaveConfig {
 }
 
 function Invoke-UI_SaveAsConfig {
-    $FilePath = Invoke-PS2EXEGUI_SaveFileDialog -Filter "PS2EXE-GUI Config (*.json)|*.json"
+    $FilePath = Invoke-PS2EXEGUI_SaveFileDialog -Filter $global:PS2EXE_GUI_CONFIG_FILTER
     if($FilePath -ne ""){ Invoke-PS2EXEGUI_SaveConfig -FilePath $FilePath }
 }
 
 function Invoke-UI_OpenConfig {
-    $FilePath = Invoke-PS2EXEGUI_OpenFileDialog -Filter "PS2EXE-GUI Config (*.json)|*.json"
+    $FilePath = Invoke-PS2EXEGUI_OpenFileDialog -Filter $global:PS2EXE_GUI_CONFIG_FILTER
     if($FilePath -ne ""){ Invoke-PS2EXEGUI_OpenConfig -FilePath $FilePath }
 }
 
@@ -487,7 +508,7 @@ function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
         $PS2EXE_API_URL = "https://api.github.com/repos/MScholtes/Win-PS2EXE/commits?path=ps2exe.ps1&page=1&per_page=1"
         $LatestCommit = (Invoke-RestMethod -Uri $PS2EXE_API_URL)[0]
         $LatestDate = [DateTime]$LatestCommit.commit.committer.date
-        $LocalPS2EXE = Join-Path (Get-Location) "ps2exe.ps1"
+        $LocalPS2EXE = Join-Path $PSScriptRoot "ps2exe.ps1"
         if(Test-Path -Path $LocalPS2EXE){
             $LocalDate = (Get-Item $LocalPS2EXE).LastWriteTime
             if($LocalDate -lt $LatestDate){

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -483,7 +483,8 @@ function Invoke-PS2EXEGUI_OpenConfig ($FilePath) {
         if($null -ne $Config.$key){
             $defaultVal = $global:PS2EXE_GUI_DEFAULTS[$key]
             if($defaultVal -is [bool]){
-                $State.$key = [bool]$Config.$key
+                try { $State.$key = [System.Convert]::ToBoolean($Config.$key) }
+                catch { $State.$key = $defaultVal }
             } else {
                 $State.$key = [string]$Config.$key
             }
@@ -510,9 +511,18 @@ function Invoke-UI_OpenConfig {
     if($FilePath -ne ""){ Invoke-PS2EXEGUI_OpenConfig -FilePath $FilePath }
 }
 
+function Install-PS2EXEUpdate ($TempFile, $Destination, $SuccessMessage) {
+    Copy-Item -Path $TempFile -Destination $Destination -Force
+    if(Test-Path -Path $Destination){
+        [System.Windows.MessageBox]::Show($SuccessMessage, "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+    } else {
+        [System.Windows.MessageBox]::Show("The file could not be saved. Please check write permissions.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
+    }
+}
+
 function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
     if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_CheckPS2EXEUpdate]" }
-    $TempFile = [System.IO.Path]::GetTempFileName()
+    $TempFile = (New-TemporaryFile).FullName
     try {
         Invoke-WebRequest -Uri $global:PS2EXE_PS1_RAW_URL -OutFile $TempFile -UseBasicParsing
         $LocalPS2EXE = Join-Path $PSScriptRoot "ps2exe.ps1"
@@ -527,12 +537,7 @@ function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
                     [System.Windows.MessageBoxImage]::Question
                 )
                 if($result -eq [System.Windows.MessageBoxResult]::Yes){
-                    Copy-Item -Path $TempFile -Destination $LocalPS2EXE -Force
-                    if(Test-Path -Path $LocalPS2EXE){
-                        [System.Windows.MessageBox]::Show("ps2exe.ps1 has been updated successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
-                    } else {
-                        [System.Windows.MessageBox]::Show("The file could not be saved. Please check write permissions.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
-                    }
+                    Install-PS2EXEUpdate -TempFile $TempFile -Destination $LocalPS2EXE -SuccessMessage "ps2exe.ps1 has been updated successfully!"
                 }
             } else {
                 [System.Windows.MessageBox]::Show("ps2exe.ps1 is already up to date.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
@@ -545,12 +550,7 @@ function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
                 [System.Windows.MessageBoxImage]::Question
             )
             if($result -eq [System.Windows.MessageBoxResult]::Yes){
-                Copy-Item -Path $TempFile -Destination $LocalPS2EXE -Force
-                if(Test-Path -Path $LocalPS2EXE){
-                    [System.Windows.MessageBox]::Show("ps2exe.ps1 has been downloaded successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
-                } else {
-                    [System.Windows.MessageBox]::Show("The file could not be saved. Please check write permissions.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
-                }
+                Install-PS2EXEUpdate -TempFile $TempFile -Destination $LocalPS2EXE -SuccessMessage "ps2exe.ps1 has been downloaded successfully!"
             }
         }
     } catch {

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -147,6 +147,7 @@ $Xaml = @"
 $PS2EXE_GUI_Verbose = $true
 $global:PS2EXE_GUI_ConfigPath = $null
 $global:PS2EXE_GUI_CONFIG_FILTER = "PS2EXE-GUI Config (*.json)|*.json"
+$global:PS2EXE_PS1_RAW_URL = "https://raw.githubusercontent.com/MScholtes/Win-PS2EXE/master/ps2exe.ps1"
 $global:PS2EXE_GUI_CONFIG_KEYS = @(
     'ui_inputFile','ui_outputFile','ui_iconFile',
     'ui_title','ui_description','ui_company','ui_product','ui_copyright','ui_trademark','ui_version',
@@ -478,7 +479,15 @@ function Invoke-PS2EXEGUI_OpenConfig ($FilePath) {
     if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_OpenConfig] FilePath: "+$FilePath) }
     $Config = Get-Content -Path $FilePath -Raw -Encoding UTF8 | ConvertFrom-Json
     $global:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object {
-        if($null -ne $Config.$_){ $State.$_ = $Config.$_ }
+        $key = $_
+        if($null -ne $Config.$key){
+            $defaultVal = $global:PS2EXE_GUI_DEFAULTS[$key]
+            if($defaultVal -is [bool]){
+                $State.$key = [bool]$Config.$key
+            } else {
+                $State.$key = [string]$Config.$key
+            }
+        }
     }
     $global:PS2EXE_GUI_ConfigPath = $FilePath
 }
@@ -503,42 +512,51 @@ function Invoke-UI_OpenConfig {
 
 function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
     if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_CheckPS2EXEUpdate]" }
+    $TempFile = [System.IO.Path]::GetTempFileName()
     try {
-        $PS2EXE_URL = "https://raw.githubusercontent.com/MScholtes/Win-PS2EXE/master/ps2exe.ps1"
-        $PS2EXE_API_URL = "https://api.github.com/repos/MScholtes/Win-PS2EXE/commits?path=ps2exe.ps1&page=1&per_page=1"
-        $LatestCommit = (Invoke-RestMethod -Uri $PS2EXE_API_URL)[0]
-        $LatestDate = [DateTime]$LatestCommit.commit.committer.date
+        Invoke-WebRequest -Uri $global:PS2EXE_PS1_RAW_URL -OutFile $TempFile -UseBasicParsing
         $LocalPS2EXE = Join-Path $PSScriptRoot "ps2exe.ps1"
         if(Test-Path -Path $LocalPS2EXE){
-            $LocalDate = (Get-Item $LocalPS2EXE).LastWriteTime
-            if($LocalDate -lt $LatestDate){
+            $LocalHash  = (Get-FileHash -Path $LocalPS2EXE -Algorithm SHA256).Hash
+            $RemoteHash = (Get-FileHash -Path $TempFile   -Algorithm SHA256).Hash
+            if($LocalHash -ne $RemoteHash){
                 $result = [System.Windows.MessageBox]::Show(
-                    "A newer version of ps2exe.ps1 is available ("+$LatestDate.ToString("yyyy-MM-dd")+").`nDownload now?",
+                    "A newer version of ps2exe.ps1 is available.`nUpdate now?",
                     "ps2exe.ps1 Update",
                     [System.Windows.MessageBoxButton]::YesNo,
                     [System.Windows.MessageBoxImage]::Question
                 )
                 if($result -eq [System.Windows.MessageBoxResult]::Yes){
-                    Invoke-WebRequest -Uri $PS2EXE_URL -OutFile $LocalPS2EXE -UseBasicParsing
-                    [System.Windows.MessageBox]::Show("ps2exe.ps1 has been updated successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+                    Copy-Item -Path $TempFile -Destination $LocalPS2EXE -Force
+                    if(Test-Path -Path $LocalPS2EXE){
+                        [System.Windows.MessageBox]::Show("ps2exe.ps1 has been updated successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+                    } else {
+                        [System.Windows.MessageBox]::Show("The file could not be saved. Please check write permissions.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
+                    }
                 }
             } else {
                 [System.Windows.MessageBox]::Show("ps2exe.ps1 is already up to date.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
             }
         } else {
             $result = [System.Windows.MessageBox]::Show(
-                "ps2exe.ps1 was not found in the current directory.`nDownload it now?",
+                "ps2exe.ps1 was not found in the script directory.`nDownload it now?",
                 "ps2exe.ps1 Update",
                 [System.Windows.MessageBoxButton]::YesNo,
                 [System.Windows.MessageBoxImage]::Question
             )
             if($result -eq [System.Windows.MessageBoxResult]::Yes){
-                Invoke-WebRequest -Uri $PS2EXE_URL -OutFile $LocalPS2EXE -UseBasicParsing
-                [System.Windows.MessageBox]::Show("ps2exe.ps1 has been downloaded successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+                Copy-Item -Path $TempFile -Destination $LocalPS2EXE -Force
+                if(Test-Path -Path $LocalPS2EXE){
+                    [System.Windows.MessageBox]::Show("ps2exe.ps1 has been downloaded successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+                } else {
+                    [System.Windows.MessageBox]::Show("The file could not be saved. Please check write permissions.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
+                }
             }
         }
     } catch {
         [System.Windows.MessageBox]::Show("Failed to check for updates:`n"+$_.Exception.Message, "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+    } finally {
+        if(Test-Path -Path $TempFile){ Remove-Item -Path $TempFile -Force -ErrorAction SilentlyContinue }
     }
 }
 #endregion 

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -145,6 +145,15 @@ $Xaml = @"
 
 #region pre_code
 $PS2EXE_GUI_Verbose = $true
+$global:PS2EXE_GUI_ConfigPath = $null
+$global:PS2EXE_GUI_CONFIG_KEYS = @(
+    'ui_inputFile','ui_outputFile','ui_iconFile',
+    'ui_title','ui_description','ui_company','ui_product','ui_copyright','ui_trademark','ui_version',
+    'value_runtime','value_instructionSet','value_threadApartment',
+    'ui_prepareDebug','ui_noConsole','ui_UNICODEEncoding','ui_credentialGUI','ui_configFile',
+    'ui_noOutput','ui_noError','ui_noVisualStyles','ui_exitOnCancel',
+    'ui_DPIAware','ui_winFormsDPIAware','ui_requireAdmin','ui_supportOS','ui_virtualize','ui_longPaths'
+)
 
 Add-Type -AssemblyName System.Windows.Forms
 
@@ -188,11 +197,11 @@ $Xaml = $Xaml.Replace('<!--d9102811-1fab-4eca-a3f6-f5b6db64722b-->',@'
 <DockPanel Name="ui_dockpanel00">
     <Menu DockPanel.Dock="Top" BorderBrush="DarkGray" BorderThickness="0,0,0,1">
         <MenuItem Header="_File">
-            <MenuItem Header="_New" Name="ui_dockpanel01" IsEnabled="false"/>
-            <MenuItem Header="_Open" Name="ui_dockpanel02" IsEnabled="false"/>
+            <MenuItem Header="_New" Name="ui_dockpanel01"/>
+            <MenuItem Header="_Open" Name="ui_dockpanel02"/>
             <Separator />
-            <MenuItem Header="_Save" Name="ui_dockpanel03" IsEnabled="false"/>
-            <MenuItem Header="_Save As..." Name="ui_dockpanel04" IsEnabled="false"/>
+            <MenuItem Header="_Save" Name="ui_dockpanel03"/>
+            <MenuItem Header="_Save As..." Name="ui_dockpanel04"/>
             <Separator />
             <MenuItem Header="_Exit" Name="ui_dockpanel05"/>
         </MenuItem>
@@ -200,8 +209,8 @@ $Xaml = $Xaml.Replace('<!--d9102811-1fab-4eca-a3f6-f5b6db64722b-->',@'
             <MenuItem Header="_View Help" Name="ui_dockpanel06"/>
             <MenuItem Header="_Send Feedback" Name="ui_dockpanel07"/>
             <Separator />
-            <MenuItem Header="_Check for PS2EXE-GUI Update" Name="ui_dockpanel08" IsEnabled="false"/>
-            <MenuItem Header="_Check for ps2exe.ps1 Update" Name="ui_dockpanel09" IsEnabled="false"/>
+            <MenuItem Header="_Check for PS2EXE-GUI Update" Name="ui_dockpanel08"/>
+            <MenuItem Header="_Check for ps2exe.ps1 Update" Name="ui_dockpanel09"/>
             <Separator />
             <MenuItem Header="_About P2EXE-GUI" Name="ui_dockpanel10"/>
         </MenuItem>
@@ -215,15 +224,15 @@ $Xaml = $Xaml.Replace('<!--039aaa3d-1014-4b1d-b7ae-6aedd03aa21b-->','</DockPanel
     - injected WPF element events are handled here
 #>
 function Invoke-WindowLoaded {
-    $ui_dockpanel01.Add_Click({Invoke-Dummy $this $_}.Ast.GetScriptBlock())
-    $ui_dockpanel02.Add_Click({Invoke-Dummy $this $_}.Ast.GetScriptBlock())
-    $ui_dockpanel03.Add_Click({Invoke-Dummy $this $_}.Ast.GetScriptBlock())
-    $ui_dockpanel04.Add_Click({Invoke-Dummy $this $_}.Ast.GetScriptBlock())
+    $ui_dockpanel01.Add_Click({Invoke-PS2EXEGUI_NewConfig $this $_}.Ast.GetScriptBlock())
+    $ui_dockpanel02.Add_Click({Invoke-UI_OpenConfig $this $_}.Ast.GetScriptBlock())
+    $ui_dockpanel03.Add_Click({Invoke-UI_SaveConfig $this $_}.Ast.GetScriptBlock())
+    $ui_dockpanel04.Add_Click({Invoke-UI_SaveAsConfig $this $_}.Ast.GetScriptBlock())
     $ui_dockpanel05.Add_Click({Stop-PS2EXEGUI $this $_}.Ast.GetScriptBlock())
     $ui_dockpanel06.Add_Click({Invoke-Hyperlink -URL "https://github.com/Hope-IT-Works/PS2EXE-GUI/wiki" $this $_}.Ast.GetScriptBlock())
     $ui_dockpanel07.Add_Click({Invoke-Hyperlink -URL "https://github.com/Hope-IT-Works/PS2EXE-GUI/issues" $this $_}.Ast.GetScriptBlock())
     $ui_dockpanel08.Add_Click({Invoke-Hyperlink -URL "https://github.com/Hope-IT-Works/PS2EXE-GUI/releases" $this $_}.Ast.GetScriptBlock())
-    $ui_dockpanel09.Add_Click({Invoke-Hyperlink -URL "https://github.com/MScholtes/Win-PS2EXE/commits/master/ps2exe.ps1" $this $_}.Ast.GetScriptBlock())
+    $ui_dockpanel09.Add_Click({Invoke-PS2EXEGUI_CheckPS2EXEUpdate $this $_}.Ast.GetScriptBlock())
     $ui_dockpanel10.Add_Click({Switch-Page -Page 1 $this $_}.Ast.GetScriptBlock())
 }
 #endregion 
@@ -419,6 +428,98 @@ function Invoke-PS2EXE {
         $State.state_compiled = $true
     }
 }
+
+function Invoke-PS2EXEGUI_NewConfig {
+    if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_NewConfig]" }
+    @('ui_inputFile','ui_outputFile','ui_iconFile','ui_title','ui_description','ui_company','ui_product','ui_copyright','ui_trademark','ui_version') | ForEach-Object {
+        $State.$_ = ""
+    }
+    $State.value_runtime = "[runtime40] .NET Framework 4.x for PowerShell 3.0"
+    $State.value_instructionSet = "x86 - 32-Bit Application"
+    $State.value_threadApartment = "STA - Single Thread Apartment"
+    @('ui_prepareDebug','ui_noConsole','ui_credentialGUI','ui_configFile','ui_noOutput','ui_noError','ui_noVisualStyles','ui_exitOnCancel','ui_DPIAware','ui_winFormsDPIAware','ui_requireAdmin','ui_virtualize','ui_longPaths') | ForEach-Object {
+        $State.$_ = $false
+    }
+    $State.ui_UNICODEEncoding = $true
+    $State.ui_supportOS = $true
+    $global:PS2EXE_GUI_ConfigPath = $null
+}
+
+function Invoke-PS2EXEGUI_SaveConfig ($FilePath) {
+    if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_SaveConfig] FilePath: "+$FilePath) }
+    $Config = [ordered]@{}
+    $global:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object { $Config[$_] = $State.$_ }
+    $Config | ConvertTo-Json | Set-Content -Path $FilePath -Encoding UTF8
+    $global:PS2EXE_GUI_ConfigPath = $FilePath
+}
+
+function Invoke-PS2EXEGUI_OpenConfig ($FilePath) {
+    if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_OpenConfig] FilePath: "+$FilePath) }
+    $Config = Get-Content -Path $FilePath -Raw -Encoding UTF8 | ConvertFrom-Json
+    $global:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object {
+        if($null -ne $Config.$_){ $State.$_ = $Config.$_ }
+    }
+    $global:PS2EXE_GUI_ConfigPath = $FilePath
+}
+
+function Invoke-UI_SaveConfig {
+    if($null -ne $global:PS2EXE_GUI_ConfigPath){
+        Invoke-PS2EXEGUI_SaveConfig -FilePath $global:PS2EXE_GUI_ConfigPath
+    } else {
+        Invoke-UI_SaveAsConfig
+    }
+}
+
+function Invoke-UI_SaveAsConfig {
+    $FilePath = Invoke-PS2EXEGUI_SaveFileDialog -Filter "PS2EXE-GUI Config (*.json)|*.json"
+    if($FilePath -ne ""){ Invoke-PS2EXEGUI_SaveConfig -FilePath $FilePath }
+}
+
+function Invoke-UI_OpenConfig {
+    $FilePath = Invoke-PS2EXEGUI_OpenFileDialog -Filter "PS2EXE-GUI Config (*.json)|*.json"
+    if($FilePath -ne ""){ Invoke-PS2EXEGUI_OpenConfig -FilePath $FilePath }
+}
+
+function Invoke-PS2EXEGUI_CheckPS2EXEUpdate {
+    if($PS2EXE_GUI_Verbose){ Write-Host "[Invoke-PS2EXEGUI_CheckPS2EXEUpdate]" }
+    try {
+        $PS2EXE_URL = "https://raw.githubusercontent.com/MScholtes/Win-PS2EXE/master/ps2exe.ps1"
+        $PS2EXE_API_URL = "https://api.github.com/repos/MScholtes/Win-PS2EXE/commits?path=ps2exe.ps1&page=1&per_page=1"
+        $LatestCommit = (Invoke-RestMethod -Uri $PS2EXE_API_URL)[0]
+        $LatestDate = [DateTime]$LatestCommit.commit.committer.date
+        $LocalPS2EXE = Join-Path (Get-Location) "ps2exe.ps1"
+        if(Test-Path -Path $LocalPS2EXE){
+            $LocalDate = (Get-Item $LocalPS2EXE).LastWriteTime
+            if($LocalDate -lt $LatestDate){
+                $result = [System.Windows.MessageBox]::Show(
+                    "A newer version of ps2exe.ps1 is available ("+$LatestDate.ToString("yyyy-MM-dd")+").`nDownload now?",
+                    "ps2exe.ps1 Update",
+                    [System.Windows.MessageBoxButton]::YesNo,
+                    [System.Windows.MessageBoxImage]::Question
+                )
+                if($result -eq [System.Windows.MessageBoxResult]::Yes){
+                    Invoke-WebRequest -Uri $PS2EXE_URL -OutFile $LocalPS2EXE -UseBasicParsing
+                    [System.Windows.MessageBox]::Show("ps2exe.ps1 has been updated successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+                }
+            } else {
+                [System.Windows.MessageBox]::Show("ps2exe.ps1 is already up to date.", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+            }
+        } else {
+            $result = [System.Windows.MessageBox]::Show(
+                "ps2exe.ps1 was not found in the current directory.`nDownload it now?",
+                "ps2exe.ps1 Update",
+                [System.Windows.MessageBoxButton]::YesNo,
+                [System.Windows.MessageBoxImage]::Question
+            )
+            if($result -eq [System.Windows.MessageBoxResult]::Yes){
+                Invoke-WebRequest -Uri $PS2EXE_URL -OutFile $LocalPS2EXE -UseBasicParsing
+                [System.Windows.MessageBox]::Show("ps2exe.ps1 has been downloaded successfully!", "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+            }
+        }
+    } catch {
+        [System.Windows.MessageBox]::Show("Failed to check for updates:`n"+$_.Exception.Message, "ps2exe.ps1 Update", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+    }
+}
 #endregion 
 #region post_code
 $UpdateSourceTrigger = 'PropertyChanged'
@@ -477,7 +578,7 @@ function FillDataContext($props){
 $DataObject =  ConvertFrom-Json @"
 
 {
-	"TabIndex" : 2,
+	"TabIndex" : 0,
 	"ui_inputFile" : "",
 	"ui_outputFile" : "",
 	"ui_iconFile" : "",

--- a/src/PS2EXE-GUI.ps1
+++ b/src/PS2EXE-GUI.ps1
@@ -471,26 +471,36 @@ function Invoke-PS2EXEGUI_SaveConfig ($FilePath) {
     if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_SaveConfig] FilePath: "+$FilePath) }
     $Config = [ordered]@{}
     $script:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object { $Config[$_] = $State.$_ }
-    $Config | ConvertTo-Json | Set-Content -Path $FilePath -Encoding UTF8
-    $script:PS2EXE_GUI_ConfigPath = $FilePath
+    try {
+        $Config | ConvertTo-Json | Set-Content -Path $FilePath -Encoding UTF8 -ErrorAction Stop
+        $script:PS2EXE_GUI_ConfigPath = $FilePath
+    } catch {
+        [System.Windows.MessageBox]::Show("The configuration could not be saved:`n"+$_.Exception.Message, "Save Config", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
+    }
 }
 
 function Invoke-PS2EXEGUI_OpenConfig ($FilePath) {
     if($PS2EXE_GUI_Verbose){ Write-Host ("[Invoke-PS2EXEGUI_OpenConfig] FilePath: "+$FilePath) }
-    $Config = Get-Content -Path $FilePath -Raw -Encoding UTF8 | ConvertFrom-Json
-    $script:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object {
-        $key = $_
-        if($null -ne $Config.$key){
-            $defaultVal = $script:PS2EXE_GUI_DEFAULTS[$key]
-            if($defaultVal -is [bool]){
-                try { $State.$key = [System.Convert]::ToBoolean($Config.$key) }
-                catch { $State.$key = $defaultVal }
-            } else {
-                $State.$key = [string]$Config.$key
+    try {
+        $rawContent = Get-Content -Path $FilePath -Raw -Encoding UTF8 -ErrorAction Stop
+        $Config = $rawContent | ConvertFrom-Json -ErrorAction Stop
+        $script:PS2EXE_GUI_DEFAULTS.GetEnumerator() | ForEach-Object { $State.($_.Key) = $_.Value }
+        $script:PS2EXE_GUI_CONFIG_KEYS | ForEach-Object {
+            $key = $_
+            if($null -ne $Config.$key){
+                $defaultVal = $script:PS2EXE_GUI_DEFAULTS[$key]
+                if($defaultVal -is [bool]){
+                    try { $State.$key = [System.Convert]::ToBoolean($Config.$key) }
+                    catch { $State.$key = $defaultVal }
+                } else {
+                    $State.$key = [string]$Config.$key
+                }
             }
         }
+        $script:PS2EXE_GUI_ConfigPath = $FilePath
+    } catch {
+        [System.Windows.MessageBox]::Show("The configuration could not be opened:`n"+$_.Exception.Message, "Open Config", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Error)
     }
-    $script:PS2EXE_GUI_ConfigPath = $FilePath
 }
 
 function Invoke-UI_SaveConfig {


### PR DESCRIPTION
This pull request adds support for saving and loading configuration files in the PS2EXE-GUI, as well as a feature to check for and update the `ps2exe.ps1` script directly from the GUI. It also updates the README to reflect these completed features and improves the usability of the File and Help menus. The most important changes are:

**New Features: Configuration Save/Load**
- Implemented functions to create a new config, save the current config, save as a new config, and open an existing config file, all using JSON format and integrated into the File menu. (`src/PS2EXE-GUI.ps1`)
- Added global variables for config paths, filters, keys, and defaults to support configuration management. (`src/PS2EXE-GUI.ps1`)

**New Feature: ps2exe.ps1 Update Check**
- Added a function to check for updates to `ps2exe.ps1`, compare hashes, prompt the user, and download or update the script as needed, with user feedback via message boxes. (`src/PS2EXE-GUI.ps1`)

**UI/UX Improvements**
- Enabled File and Help menu items for new, open, save, save as, and update actions, and wired them to the new functions for configuration and update management. (`src/PS2EXE-GUI.ps1`) [[1]](diffhunk://#diff-c29c53688ac3248f1d41c243a09f6d08fc0e19806927332b91737dbe6664f428L191-R247) [[2]](diffhunk://#diff-c29c53688ac3248f1d41c243a09f6d08fc0e19806927332b91737dbe6664f428L218-R267)
- Fixed a typo in the About menu entry ("P2EXE-GUI" to "PS2EXE-GUI"). (`src/PS2EXE-GUI.ps1`)

**Documentation**
- Updated the `README.md` to mark the "add ps2exe-script update" and "add save files" features as complete. (`README.md`)

**Minor Default/Behavioral Changes**
- Changed the default tab index from 2 to 0 in the data context. (`src/PS2EXE-GUI.ps1`)